### PR TITLE
Process a single explicit OPC UA parser input

### DIFF
--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
@@ -1458,6 +1458,7 @@ public class DomParser {
         ArrayList<File> files = new ArrayList<File>();
         if (args.length == 1) {
             file = new File(args[0]);
+            files.add(file);
         } else {
             File baseDir = new File("src/main/resources/NodeSets/");
             files.add(new File(baseDir, "Opc.Ua.Woodworking.NodeSet2.xml"));

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -28,6 +28,26 @@ import de.iip_ecosphere.platform.support.FileUtils;
  * @author Holger Eichelberger, SSE
  */
 public class DomParserTest {
+
+    /**
+     * Tests processing one explicitly supplied companion specification.
+     */
+    @Test
+    public void testDomParserSingleInput() {
+        File in = new File("src/test/resources/NodeSets/Opc.Ua.MachineTool.NodeSet2.xml");
+        Assert.assertTrue(in.isFile());
+        File out = new File("target/gen/OpcMachineTool.ivml");
+        out.getParentFile().mkdirs();
+        if (out.exists()) {
+            Assert.assertTrue(out.delete());
+        }
+        DomParser.setDefaultVerbose(false);
+        DomParser.setUsingIvmlFolder("target/tmp");
+
+        DomParser.main(new String[] {in.toString()});
+
+        Assert.assertTrue(out.isFile());
+    }
     
     /**
      * Tests {@link DomParser} on the machine tool companion spec XML.


### PR DESCRIPTION
Purpose:
Fix processing of one explicitly supplied OPC UA NodeSet file.

Observed behavior:
With exactly one argument, DomParser created a File instance but did not add it to the collection processed by the main loop.

Root cause:
The single-input branch assigned the argument only to a local variable.

Change:
Add the single explicit input to the existing processing collection while leaving the zero-argument default batch and all other argument-count behavior unchanged.

Necessity by file:
- DomParser.java: adds the already constructed single input to the existing processing list.
- DomParserTest.java: adds a separate regression test proving that main creates the expected IVML output for one explicit NodeSet, without changing the existing process-based tests.

Architecture:
No dependency, plugin, naming, generator, validation, or general CLI-policy change.

Validation:
mvn -PCfg -Dtest=DomParserTest test
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0.
git diff --check passed.