### PR TITLE
Generalize OPC UA parser input-set handling

### DIFF
--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
@@ -1456,9 +1456,10 @@ public class DomParser {
     public static void main(String[] args) {
         File file;
         ArrayList<File> files = new ArrayList<File>();
-        if (args.length == 1) {
-            file = new File(args[0]);
-            files.add(file);
+        if (args.length > 0) {
+            for (String argument : args) {
+                files.add(new File(argument));
+            }
         } else {
             File baseDir = new File("src/main/resources/NodeSets/");
             files.add(new File(baseDir, "Opc.Ua.Woodworking.NodeSet2.xml"));

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -12,8 +12,10 @@
 
 package test.de.iip_ecosphere.platform.configuration.easyProducer.opcua;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.Charset;
 
 import org.junit.Assert;
@@ -47,6 +49,47 @@ public class DomParserTest {
         DomParser.main(new String[] {in.toString()});
 
         Assert.assertTrue(out.isFile());
+    }
+
+    /**
+     * Tests processing explicit inputs exactly once in caller order.
+     */
+    @Test
+    public void testDomParserMultipleInputs() {
+        File first = new File("src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml");
+        File second = new File("src/test/resources/NodeSets/Opc.Ua.MachineTool.NodeSet2.xml");
+        File firstOut = new File("target/gen/OpcWoodworking.ivml");
+        File secondOut = new File("target/gen/OpcMachineTool.ivml");
+        Assert.assertTrue(first.isFile());
+        Assert.assertTrue(second.isFile());
+        firstOut.getParentFile().mkdirs();
+        if (firstOut.exists()) {
+            Assert.assertTrue(firstOut.delete());
+        }
+        if (secondOut.exists()) {
+            Assert.assertTrue(secondOut.delete());
+        }
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        PrintStream previousOut = System.out;
+        try {
+            System.setOut(new PrintStream(buffer));
+            DomParser.setDefaultVerbose(false);
+            DomParser.setUsingIvmlFolder("target/tmp");
+            DomParser.main(new String[] {first.toString(), second.toString()});
+        } finally {
+            System.setOut(previousOut);
+        }
+
+        Assert.assertTrue(firstOut.isFile());
+        Assert.assertTrue(secondOut.isFile());
+        String output = new String(buffer.toByteArray(), Charset.defaultCharset());
+        String firstMessage = "Processing " + first;
+        String secondMessage = "Processing " + second;
+        Assert.assertTrue(output.indexOf(firstMessage) >= 0);
+        Assert.assertTrue(output.indexOf(secondMessage) >= 0);
+        Assert.assertTrue(output.indexOf(firstMessage) < output.indexOf(secondMessage));
+        Assert.assertEquals(output.indexOf(firstMessage), output.lastIndexOf(firstMessage));
+        Assert.assertEquals(output.indexOf(secondMessage), output.lastIndexOf(secondMessage));
     }
     
     /**


### PR DESCRIPTION
Purpose:
Allow DomParser to process an arbitrary set of explicitly supplied OPC UA NodeSet files.

Observed behavior:
After fixing one explicit input, argument counts greater than one still selected the bundled default batch instead of the caller inputs.

Root cause:
The explicit-input branch was limited to exactly one argument.

Change:
Add every supplied argument to the existing processing list in caller order while preserving the zero-argument default batch.

Necessity by file:
- DomParser.java: generalizes the explicit-input branch without changing the processing loop.
- DomParserTest.java: proves two public NodeSets are each processed once, generate their expected IVML files, and are processed in caller order.

Architecture:
No validation, dependency, plugin, naming, generator, parser-error, or output-policy change is introduced.

Validation:
mvn -PCfg -Dtest=DomParserTest test
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0.
git diff --check passed.