### PR TITLE
Propagate OPC UA NodeSet parsing failures

### DIFF
--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
@@ -1394,7 +1394,7 @@ public class DomParser {
             Collector.collectInformation(compSpec.getName(), objectTypeList, objectList, variableList, methodList,
                     dataTypeList, variableTypeList, hierarchy, reqModels.length);
         } catch (ParserConfigurationException | SAXException | IOException e) {
-            System.out.println(e.getMessage());
+            throw new IllegalArgumentException("Cannot parse OPC UA NodeSet '" + compSpec + "': " + e.getMessage(), e);
         }
         return parser;
     }

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -13,11 +13,13 @@
 package test.de.iip_ecosphere.platform.configuration.easyProducer.opcua;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import de.iip_ecosphere.platform.configuration.easyProducer.opcua.parser.DomParser;
 import de.iip_ecosphere.platform.support.FileUtils;
@@ -47,6 +49,30 @@ public class DomParserTest {
         DomParser.main(new String[] {in.toString()});
 
         Assert.assertTrue(out.isFile());
+    }
+
+    /**
+     * Tests propagation of XML parser failures.
+     *
+     * @throws IOException shall not occur
+     */
+    @Test
+    public void testParserErrorPropagation() throws IOException {
+        File tmp = new File("target/tmp");
+        tmp.mkdirs();
+        File invalid = File.createTempFile("invalid-opcua-input-", ".xml", tmp);
+        try (FileWriter writer = new FileWriter(invalid)) {
+            writer.write("<invalid>");
+        }
+        try {
+            DomParser.process(invalid, "Invalid", new File(tmp, "OpcInvalid.ivml"), false);
+            Assert.fail("Expected malformed XML input to be rejected");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains(invalid.toString()));
+            Assert.assertTrue(e.getCause() instanceof SAXException);
+        } finally {
+            Assert.assertTrue(invalid.delete());
+        }
     }
     
     /**


### PR DESCRIPTION
Purpose:
Expose OPC UA XML parsing failures directly to callers.

Observed behavior:
Parser configuration, SAX, and I/O failures were printed and swallowed, after which processing continued with a null parser and obscured the original error.

Root cause:
createParser caught checked parsing failures without propagating them.

Change:
Throw IllegalArgumentException with the failing NodeSet path and retain the original checked exception as its cause.

Necessity by file:
- DomParser.java: propagates the original parsing failure instead of returning a null parser.
- DomParserTest.java: verifies malformed XML fails through process() with its SAXException cause preserved.

Architecture:
No input-selection, validation, dependency, plugin, naming, generator, or output-policy change is introduced.

Validation:
mvn -PCfg -Dtest=DomParserTest test
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0.
git diff --check passed.