### PR TITLE
Resolve external OPC UA root-variable types

### DIFF
--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
@@ -551,7 +551,7 @@ public class DomParser {
                         if (type == ElementType.ROOTOBJECT || type == ElementType.SUBOBJECT) {
                             typeList = documents[i].getElementsByTagName("UAObjectType");
                             type = ElementType.OBJECTTYPE;
-                        } else if (type == ElementType.FIELDVARIABLE) {
+                        } else if (type == ElementType.FIELDVARIABLE || type == ElementType.ROOTVARIABLE) {
                             typeList = documents[i].getElementsByTagName("UAVariableType");
                             type = ElementType.VARIABLETYPE;
                         }

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -75,6 +75,39 @@ public class DomParserTest {
     }
 
     /**
+     * Tests resolving an external type definition for root variables.
+     *
+     * @throws IOException shall not occur
+     */
+    @Test
+    public void testExternalRootVariableTypeDefinition() throws IOException {
+        File in = new File("src/test/resources/NodeSets/Opc.Ua.ExternalRootVariable.NodeSet2.xml");
+        Assert.assertTrue(in.isFile());
+        File tmp = new File("target/tmp");
+        tmp.mkdirs();
+        File out = new File(tmp, "OpcExternalRootVariable.ivml");
+        if (out.exists()) {
+            Assert.assertTrue(out.delete());
+        }
+
+        DomParser.setUsingIvmlFolder("target/tmp");
+        DomParser.process(in, "ExternalRootVariable", out, false);
+
+        Assert.assertTrue(out.isFile());
+        String contents = FileUtils.readFileToString(out, Charset.forName("UTF-8"));
+        Assert.assertTrue(contents.contains("UAVariableTypeType opcExternalMeasurementValueTypeType"));
+        Assert.assertTrue(contents.contains("nodeId = {nameSpaceIndex = 2, identifier = 2001}"));
+        Assert.assertTrue(contents.contains("UARootVariableType opcSyntheticRootTypePressure"));
+        Assert.assertTrue(contents.contains("nodeId = {nameSpaceIndex = 1, identifier = 6001}"));
+        Assert.assertTrue(contents.contains("typeDefinition = refBy(opcExternalMeasurementValueTypeType)"));
+        Assert.assertTrue(contents.contains("rootParent = refBy(opcSyntheticRootType)"));
+        Assert.assertTrue(contents.contains("optional = false,\n\t\ttype = refBy(FloatType)"));
+        Assert.assertTrue(contents.contains("UARootVariableType opcSyntheticRootTypeTemperature"));
+        Assert.assertTrue(contents.contains("nodeId = {nameSpaceIndex = 1, identifier = 6002}"));
+        Assert.assertTrue(contents.contains("optional = true,\n\t\ttype = refBy(DoubleType)"));
+    }
+
+    /**
      * Tests {@link DomParser} on the woodworking companion spec XML.
      * 
      * @throws IOException shall not occur

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalRootVariable.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalRootVariable.NodeSet2.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalRootVariable/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalVariableType/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalRootVariable/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalVariableType/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:SyntheticRootType">
+    <DisplayName>SyntheticRootType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6001</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=6002</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=6001" BrowseName="1:Pressure"
+      ParentNodeId="ns=1;i=1001" DataType="Float" AccessLevel="3">
+    <DisplayName>Pressure</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=78</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=2;i=2001</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=6002" BrowseName="1:Temperature"
+      ParentNodeId="ns=1;i=1001" DataType="Double" AccessLevel="3">
+    <DisplayName>Temperature</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=2;i=2001</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAVariable>
+</UANodeSet>

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/RequiredModels/Opc.Ua.ExternalVariableType.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/RequiredModels/Opc.Ua.ExternalVariableType.NodeSet2.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalVariableType/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalVariableType/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAVariableType NodeId="ns=1;i=2001" BrowseName="1:ExternalMeasurementValueType"
+      DataType="Float" ValueRank="-2">
+    <DisplayName>ExternalMeasurementValueType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=63</Reference>
+    </References>
+  </UAVariableType>
+</UANodeSet>


### PR DESCRIPTION
## Purpose

Resolve external `VariableType` references for OPC UA variables classified as
root variables.

## Problem

For a local `UAVariable` with an external `HasTypeDefinition`, the external
resolution path selected a `UAVariableType` list only for `FIELDVARIABLE`.

For `ROOTVARIABLE`, the node list remained `null`, causing a
`NullPointerException` during relation lookup.

## Change

Route `ROOTVARIABLE` through the existing external `UAVariableType` resolution
path, matching the behavior already used by the local and core resolution paths.

## Scope

The production change is limited to one condition in `DomParser`.

The pull request also adds:

- one focused structural regression test;
- one synthetic local NodeSet;
- one synthetic external RequiredModel.

No changes were made to:

- namespace-to-model mapping;
- RequiredModel discovery;
- generator behavior;
- CLI handling;
- naming;
- plugins;
- dependencies;
- POM files.

## Validation

- Original Machinery Energy reproduction: `BUILD SUCCESS`
- `DomParserTest`: 4 tests, 0 failures, 0 errors
- Complete `configuration.easy` module: 26 tests, 0 failures, 0 errors
- `git diff --check`: passed

The original external-root-variable `NullPointerException` is fully resolved.

### Review note

`DomParser.java` contains pre-existing non-UTF-8 bytes. The production change
was applied byte-preservingly. The resulting production diff contains only the
single condition change shown in this pull request.
