### PR TITLE
Resolve OPC UA references by namespace URI

### DIFF
--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
@@ -86,6 +86,7 @@ public class DomParser {
     private ArrayList<BaseType> hierarchy;
     private boolean verbose = verboseDefault;
     private String baseNameSpace;
+    private NodeList namespaceUris;
     private ArrayList<NodeList> externAliasLists;
 
     // checkstyle: stop parameter number check
@@ -356,6 +357,75 @@ public class DomParser {
     }
 
     /**
+     * Returns the namespace URI denoted by the namespace index in {@code nodeId}.
+     *
+     * @param nodeId the node id in the source document
+     * @return the namespace URI
+     */
+    private String getNamespaceUri(String nodeId) {
+        int start = nodeId.indexOf("ns=") + 3;
+        int end = nodeId.indexOf(";", start);
+        int namespaceIndex = Integer.parseInt(nodeId.substring(start, end));
+        NodeList uris = ((Element) namespaceUris.item(0)).getElementsByTagName("Uri");
+        if (namespaceIndex <= 0 || namespaceIndex > uris.getLength()) {
+            throw new IllegalArgumentException("No namespace URI for " + nodeId);
+        }
+        return uris.item(namespaceIndex - 1).getTextContent();
+    }
+
+    /**
+     * Returns the loaded document declaring {@code namespaceUri} as its model URI.
+     *
+     * @param namespaceUri the namespace URI
+     * @return the matching document
+     */
+    private Document getRequiredModel(String namespaceUri) {
+        Document result = null;
+        for (Document document : documents) {
+            Node model = document.getElementsByTagName("Model").item(0);
+            if (model instanceof Element && namespaceUri.equals(((Element) model).getAttribute("ModelUri"))) {
+                result = document;
+                break;
+            }
+        }
+        if (result == null) {
+            throw new IllegalArgumentException("No required model loaded for namespace URI " + namespaceUri);
+        }
+        return result;
+    }
+
+    /**
+     * Returns the namespace index of {@code namespaceUri} in {@code document}.
+     *
+     * @param document the target document
+     * @param namespaceUri the namespace URI
+     * @return the namespace index
+     */
+    private static int getNamespaceIndex(Document document, String namespaceUri) {
+        NodeList namespaceUriElements = document.getElementsByTagName("NamespaceUris");
+        NodeList uris = ((Element) namespaceUriElements.item(0)).getElementsByTagName("Uri");
+        for (int i = 0; i < uris.getLength(); i++) {
+            if (namespaceUri.equals(uris.item(i).getTextContent())) {
+                return i + 1;
+            }
+        }
+        throw new IllegalArgumentException("No namespace index for " + namespaceUri + " in required model");
+    }
+
+    /**
+     * Replaces the namespace index in {@code nodeId}.
+     *
+     * @param nodeId the node id
+     * @param namespaceIndex the new namespace index
+     * @return the adjusted node id
+     */
+    private static String replaceNamespaceIndex(String nodeId, int namespaceIndex) {
+        int start = nodeId.indexOf("ns=") + 3;
+        int end = nodeId.indexOf(";", start);
+        return nodeId.substring(0, start) + namespaceIndex + nodeId.substring(end);
+    }
+
+    /**
      * Returns the next node element.
      * 
      * @param nodes    the nodes to search for
@@ -544,32 +614,24 @@ public class DomParser {
                     }
                 } else {
                     // other models
-                    String newRefId = refId.substring(0, refId.indexOf("=") + 1) + 1
-                            + refId.substring(refId.indexOf(";"), refId.length());
-                    for (int i = 1; i < documents.length; i++) {
-                        NodeList typeList = null;
-                        if (type == ElementType.ROOTOBJECT || type == ElementType.SUBOBJECT) {
-                            typeList = documents[i].getElementsByTagName("UAObjectType");
-                            type = ElementType.OBJECTTYPE;
-                        } else if (type == ElementType.FIELDVARIABLE || type == ElementType.ROOTVARIABLE) {
-                            typeList = documents[i].getElementsByTagName("UAVariableType");
-                            type = ElementType.VARIABLETYPE;
-                        }
-                        Element refElement = checkRelation(newRefId, typeList);
-                        if (refElement != null) {
-                            DescriptionOrDocumentation d = getDescriptionOrDocumentation(reference, refElement);
-                            // create Attribute
-                            reference = d.reference;
-                            createElement(type, refElement, refId, d.displayName, d.description, d.documentation, null,
-                                    null, null, null, null, false);
-                            break;
-                        } else if (type == ElementType.OBJECTTYPE) {
-                            type = ElementType.ROOTOBJECT;
-                        } else if (type == ElementType.VARIABLETYPE) {
-                            type = ElementType.FIELDVARIABLE;
-                        }
+                    String namespaceUri = getNamespaceUri(refId);
+                    Document document = getRequiredModel(namespaceUri);
+                    String newRefId = replaceNamespaceIndex(refId, getNamespaceIndex(document, namespaceUri));
+                    NodeList typeList = null;
+                    if (type == ElementType.ROOTOBJECT || type == ElementType.SUBOBJECT) {
+                        typeList = document.getElementsByTagName("UAObjectType");
+                        type = ElementType.OBJECTTYPE;
+                    } else if (type == ElementType.FIELDVARIABLE || type == ElementType.ROOTVARIABLE) {
+                        typeList = document.getElementsByTagName("UAVariableType");
+                        type = ElementType.VARIABLETYPE;
                     }
-
+                    Element refElement = checkRelation(newRefId, typeList);
+                    if (refElement != null) {
+                        DescriptionOrDocumentation d = getDescriptionOrDocumentation(reference, refElement);
+                        reference = d.reference;
+                        createElement(type, refElement, refId, d.displayName, d.description, d.documentation, null,
+                                null, null, null, null, false);
+                    }
                 }
                 break;
             }
@@ -1376,6 +1438,7 @@ public class DomParser {
 
             parser = new DomParser(objectTypeList, objectList, variableList, methodList, dataTypeList, variableTypeList,
                     aliasList, hierarchy);
+            parser.namespaceUris = nameSpaceUris;
             File[] reqModels = checkRequiredModels(parser, modelName, path,
                     toOsPath(compSpec).replace(toOsPath(path + "/Opc.Ua."), "").replace(".NodeSet.xml", ""),
                     nameSpaceUris);

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -191,6 +191,7 @@ public class DomParserTest {
 
     /**
      * Tests propagation of XML parser failures.
+     * Tests namespace-aware resolution if a colliding required model is loaded first.
      *
      * @throws IOException shall not occur
      */
@@ -212,6 +213,37 @@ public class DomParserTest {
             Assert.assertTrue(invalid.delete());
         }
     }    
+    public void testExternalReferenceResolutionWrongFirst() throws IOException {
+        assertExternalReferenceResolution("WrongFirst");
+    }
+
+    /**
+     * Tests namespace-aware resolution if the referenced required model is loaded first.
+     *
+     * @throws IOException shall not occur
+     */
+    @Test
+    public void testExternalReferenceResolutionCorrectFirst() throws IOException {
+        assertExternalReferenceResolution("CorrectFirst");
+    }
+
+    /**
+     * Tests rejecting an external reference with an unknown source namespace index.
+     */
+    @Test
+    public void testUnknownExternalNamespaceIndex() {
+        File in = new File("src/test/resources/NodeSets/Opc.Ua.ExternalReferenceUnknownNamespace.NodeSet2.xml");
+        Assert.assertTrue(in.isFile());
+        File out = new File("target/tmp/ExternalReferenceUnknownNamespace.ivml");
+
+        try {
+            DomParser.process(in, "ExternalReferenceUnknownNamespace", out, false);
+            Assert.fail("Expected an invalid namespace index to be rejected");
+        } catch (IllegalArgumentException e) {
+            Assert.assertTrue(e.getMessage().contains("No namespace URI"));
+            Assert.assertTrue(e.getMessage().contains("ns=4;i=1002"));
+        }
+    }
     
     /**
      * Tests {@link DomParser} on the machine tool companion spec XML.
@@ -236,6 +268,36 @@ public class DomParserTest {
         String exContents = normalize(FileUtils.readFileToString(expected, charset));
         String outContents = normalize(FileUtils.readFileToString(out, charset));
         Assert.assertEquals(exContents, outContents);
+        Assert.assertTrue(outContents.contains("UADataType opcNumberType = {"));
+        Assert.assertTrue(outContents.contains("UADataType opcLocalizedTextType = {"));
+        Assert.assertTrue(outContents.contains("UADataType opcUtcTimeType = {"));
+        Assert.assertTrue(outContents.contains("UADataType opcNodeIdType = {"));
+    }
+
+    /**
+     * Parses and checks a synthetic external-reference case.
+     *
+     * @param order the required-model order suffix
+     * @throws IOException shall not occur
+     */
+    private void assertExternalReferenceResolution(String order) throws IOException {
+        String name = "ExternalReferenceResolution" + order;
+        File in = new File("src/test/resources/NodeSets/Opc.Ua." + name + ".NodeSet2.xml");
+        Assert.assertTrue(in.isFile());
+        File out = new File("target/tmp", name + ".ivml");
+        out.getParentFile().mkdirs();
+        if (out.exists()) {
+            Assert.assertTrue(out.delete());
+        }
+
+        DomParser.setDefaultVerbose(false);
+        DomParser.setUsingIvmlFolder("target/tmp");
+        DomParser.process(in, name, out, false);
+
+        String contents = normalize(FileUtils.readFileToString(out, Charset.forName("UTF-8")));
+        Assert.assertTrue(contents.contains("typeDefinition = refBy(opcCorrectTargetType)"));
+        Assert.assertTrue(contents.contains("UAObjectTypeType opcCorrectTargetType = {"));
+        Assert.assertFalse(contents.contains("opcWrongTargetType"));
     }
 
     /**
@@ -294,6 +356,7 @@ public class DomParserTest {
         String exContents = normalize(FileUtils.readFileToString(expected, charset));
         String outContents = normalize(FileUtils.readFileToString(out, charset));
         Assert.assertEquals(exContents, outContents);
+        Assert.assertTrue(outContents.contains("UADataType opcGuidType = {"));
     }
 
     /**

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalReferenceResolutionCorrectFirst.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalReferenceResolutionCorrectFirst.NodeSet2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceResolution/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceCorrect/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceWrong/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalReferenceResolution/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalReferenceCorrect/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalReferenceWrong/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:ExternalReferenceRootType">
+    <DisplayName>ExternalReferenceRootType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=5001</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=5001" BrowseName="1:Thing" ParentNodeId="ns=1;i=1001">
+    <DisplayName>Thing</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=2;i=1002</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+</UANodeSet>

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalReferenceResolutionWrongFirst.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalReferenceResolutionWrongFirst.NodeSet2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceResolution/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceWrong/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceCorrect/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalReferenceResolution/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalReferenceWrong/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalReferenceCorrect/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:ExternalReferenceRootType">
+    <DisplayName>ExternalReferenceRootType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=5001</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=5001" BrowseName="1:Thing" ParentNodeId="ns=1;i=1001">
+    <DisplayName>Thing</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=3;i=1002</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+</UANodeSet>

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalReferenceUnknownNamespace.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/Opc.Ua.ExternalReferenceUnknownNamespace.NodeSet2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceResolution/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceCorrect/</Uri>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceWrong/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalReferenceResolution/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalReferenceCorrect/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/ExternalReferenceWrong/"
+          Version="1.00" PublicationDate="2026-07-24T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:ExternalReferenceRootType">
+    <DisplayName>ExternalReferenceRootType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=5001</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=5001" BrowseName="1:Thing" ParentNodeId="ns=1;i=1001">
+    <DisplayName>Thing</DisplayName>
+    <References>
+      <Reference ReferenceType="HasModellingRule">i=80</Reference>
+      <Reference ReferenceType="HasTypeDefinition">ns=4;i=1002</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+</UANodeSet>

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/RequiredModels/Opc.Ua.ExternalReferenceCorrect.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/RequiredModels/Opc.Ua.ExternalReferenceCorrect.NodeSet2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceCorrect/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalReferenceCorrect/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:CorrectTargetType">
+    <DisplayName>CorrectTargetType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+</UANodeSet>

--- a/platform/configuration/configuration.easy/src/test/resources/NodeSets/RequiredModels/Opc.Ua.ExternalReferenceWrong.NodeSet2.xml
+++ b/platform/configuration/configuration.easy/src/test/resources/NodeSets/RequiredModels/Opc.Ua.ExternalReferenceWrong.NodeSet2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UANodeSet xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <NamespaceUris>
+    <Uri>http://opcfoundation.org/UA/ExternalReferenceWrong/</Uri>
+  </NamespaceUris>
+  <Models>
+    <Model ModelUri="http://opcfoundation.org/UA/ExternalReferenceWrong/"
+        Version="1.00" PublicationDate="2026-07-24T00:00:00Z">
+      <RequiredModel ModelUri="http://opcfoundation.org/UA/"
+          Version="1.05.02" PublicationDate="2022-11-01T00:00:00Z" />
+    </Model>
+  </Models>
+  <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:WrongTargetType">
+    <DisplayName>WrongTargetType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+</UANodeSet>

--- a/platform/configuration/configuration.easy/src/test/resources/OpcMachineTool.ivml
+++ b/platform/configuration/configuration.easy/src/test/resources/OpcMachineTool.ivml
@@ -708,14 +708,14 @@ project OpcMachineTool {
 		}
 	};
 
-	UAObjectTypeType opcMachineryItemStateStateMachineType = {
-		name = "opcMachineryItemStateStateMachineType",
+	UAObjectTypeType opcBasicStacklightType = {
+		name = "opcBasicStacklightType",
 		nodeId = {nameSpaceIndex = 4, identifier = 1002},
 		nodeClass = NodeClass::UAObjectType,
-		browseName = "1:MachineryItemState_StateMachineType",
-		displayName = "MachineryItemState_StateMachineType",
-		description = "State machine representing the state of a machinery item",
-		documentation = "https://reference.opcfoundation.org/v104/Machinery/v101/docs/12.2"
+		browseName = "1:BasicStacklightType",
+		displayName = "BasicStacklightType",
+		description = "Entry point to a stacklight containing elements of the stacklight as well as additional information valid for the whole unit.",
+		documentation = "https://reference.opcfoundation.org/v105/IA/v102/docs/5.2.1"
 	};
 
 	UARootObjectType opcMonitoringTypeStacklight = {
@@ -726,7 +726,7 @@ project OpcMachineTool {
 		displayName = "Stacklight",
 		description = "",
 		optional = true,
-		typeDefinition = refBy(opcMachineryItemStateStateMachineType),
+		typeDefinition = refBy(opcBasicStacklightType),
 		rootParent = refBy(opcMonitoringType),
 		fields = {
 			UAFieldObjectType {
@@ -827,14 +827,14 @@ project OpcMachineTool {
 		}
 	};
 
-	UAObjectTypeType opcMachineComponentsType = {
-		name = "opcMachineComponentsType",
+	UAObjectTypeType opcStackElementLightType = {
+		name = "opcStackElementLightType",
 		nodeId = {nameSpaceIndex = 4, identifier = 1006},
 		nodeClass = NodeClass::UAObjectType,
-		browseName = "1:MachineComponentsType",
-		displayName = "MachineComponentsType",
-		description = "Contains all identifiable components of a machine",
-		documentation = "https://reference.opcfoundation.org/v104/Machinery/v101/docs/11.2"
+		browseName = "1:StackElementLightType",
+		displayName = "StackElementLightType",
+		description = "Represents a lamp element in a stacklight.",
+		documentation = "https://reference.opcfoundation.org/v105/IA/v102/docs/5.2.6"
 	};
 
 	UAObjectType opcMonitoringTypeStacklightOrderedObject = {
@@ -845,7 +845,7 @@ project OpcMachineTool {
 		displayName = "<OrderedObject>",
 		description = "",
 		optional = false,
-		typeDefinition = refBy(opcMachineComponentsType),
+		typeDefinition = refBy(opcStackElementLightType),
 		fields = {
 			UAFieldVariableType {
 				name = "opcOrderedObjectNumberInList",


### PR DESCRIPTION
## Purpose

Resolve external OPC UA references in the model identified by the source
namespace URI.

## Problem

External references were translated to a local namespace index and then
resolved by searching loaded RequiredModels in load order.

When multiple models contained the same local NodeId, the first match was
selected even if the source namespace index referred to a different model.

For example, MachineTool references IA types through namespace index 4, but
equal NodeIds in Machinery could be selected first.

## Root cause

The parser did not preserve the mapping from the source namespace index to the
corresponding namespace and model URI during external reference resolution.

## Change

The parser now:

- preserves the source `NamespaceUris` internally;
- maps an external reference namespace index to its namespace URI;
- selects the loaded RequiredModel with the matching model URI;
- translates the reference to the target document's internal namespace index;
- searches only the matching model.

The implementation adds four private helper methods:

- `getNamespaceUri`
- `getRequiredModel`
- `getNamespaceIndex`
- `replaceNamespaceIndex`

No public API is introduced.

## Corrected MachineTool mappings

The existing complete MachineTool Golden comparison remains active. Only two
previously incorrect expectations are changed:

- `ns=4;i=1002`
  - previously: `MachineryItemState_StateMachineType`
  - now: `BasicStacklightType`

- `ns=4;i=1006`
  - previously: `MachineComponentsType`
  - now: `StackElementLightType`

The complete Woodworking Golden comparison remains unchanged.

## Regression coverage

Synthetic NodeSets cover two RequiredModel load orders where both external
models contain the same internal NodeId.

Both orders now resolve to the same expected type, independent of the
document order.

An additional regression covers an invalid external namespace index and checks
that the resulting exception includes the offending reference and source
context.

## Validation

- `mvn -PCfg -Dtest=DomParserTest test`
- `mvn -PCfg -Dtest=DomParserTest#testDomParserMachineTool test`
- `mvn -PCfg -Dtest=DomParserTest#testDomParserWoodworking test`
- `mvn -PCfg test`
- `git diff --check`

