### PR TITLE
Provide an opt-in OPC UA parser execution profile

### DIFF
--- a/platform/configuration/configuration.easy/README.md
+++ b/platform/configuration/configuration.easy/README.md
@@ -152,6 +152,20 @@ In addition, the meta-model contains two specialized type models for OPC UA (com
 
 The IDTA tools are meant to be proof-of-context implementations as the specifications/formats allow for many variations. The IDTA tools also contain a program to structurally compare models as well as a program to load AASX files via multiple versions of BaSyx.
 
+### OPC UA NodeSet parser
+
+The `OpcUaParser` profile provides the runtime provider needed to execute the OPC UA NodeSet-to-IVML parser as a development tool. The generated IVML is used by subsequent configuration and generation steps; the profile and parser provider are not required by the platform runtime.
+
+From this module, run:
+
+```
+mvn -PCfg,OpcUaParser compile exec:java \
+    -Dopcua.ivml.output=target/opcua-parser \
+    -Dexec.args=src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml
+```
+
+The output folder is created automatically. It contains the generated `OpcWoodworking.ivml`, `VDW.ivml` and `VDW_Woodworking.ivml` files.
+
 ## The resources folder
 
 The resources directory contains files that shall be packaged into platform jars or into an application artifact during platform/application instantiation. It is split into

--- a/platform/configuration/configuration.easy/README.md
+++ b/platform/configuration/configuration.easy/README.md
@@ -154,17 +154,22 @@ The IDTA tools are meant to be proof-of-context implementations as the specifica
 
 ### OPC UA NodeSet parser
 
-The `OpcUaParser` profile provides the runtime provider needed to execute the OPC UA NodeSet-to-IVML parser as a development tool. The generated IVML is used by subsequent configuration and generation steps; the profile and parser provider are not required by the platform runtime.
+The `OpcUaParser` profile provides the runtime provider needed to execute the OPC UA NodeSet-to-IVML parser as a development tool. The input NodeSet must be specified. The generated IVML is used by subsequent configuration and generation steps; the profile and parser provider are not required by the platform runtime.
 
 From this module, run:
 
 ```
 mvn -PCfg,OpcUaParser compile exec:java \
-    -Dopcua.ivml.output=target/opcua-parser \
     -Dexec.args=src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml
 ```
 
-The output folder is created automatically. It contains the generated `OpcWoodworking.ivml`, `VDW.ivml` and `VDW_Woodworking.ivml` files.
+The optional output property defaults to `target/opcua-parser`. The folder is created automatically and contains the generated `OpcWoodworking.ivml`, `VDW.ivml` and `VDW_Woodworking.ivml` files. To use a different output folder, run:
+
+```
+mvn -PCfg,OpcUaParser compile exec:java \
+    -Dopcua.ivml.output=/path/to/output \
+    -Dexec.args=/path/to/NodeSet.xml
+```
 
 ## The resources folder
 

--- a/platform/configuration/configuration.easy/pom.xml
+++ b/platform/configuration/configuration.easy/pom.xml
@@ -360,6 +360,31 @@
      </profile>
 
      <profile>
+        <id>OpcUaParser</id>
+        <dependencies>
+          <dependency>
+            <groupId>de.iip-ecosphere.platform</groupId>
+            <artifactId>support.commons-apache</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>exec-maven-plugin</artifactId>
+              <version>3.0.0</version>
+              <configuration>
+                <mainClass>de.iip_ecosphere.platform.configuration.easyProducer.opcua.parser.DomParser</mainClass>
+                <classpathScope>runtime</classpathScope>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+     </profile>
+
+     <profile>
         <id>Main</id>
         <activation>
            <activeByDefault>true</activeByDefault>

--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/DomParser.java
@@ -61,8 +61,9 @@ enum ElementType {
  */
 public class DomParser {
 
+    private static final String IVML_OUTPUT_PROPERTY = "opcua.ivml.output";
     private static boolean verboseDefault = false;
-    private static String usingIvmlFolder = "src/test/easy";
+    private static String usingIvmlFolder = System.getProperty(IVML_OUTPUT_PROPERTY, "target/opcua-parser");
     private static final Set<String> IDENTIFY_FIELDS_PERMITTED_REFERENCE_TYPE;
 
     static {
@@ -1402,10 +1403,24 @@ public class DomParser {
     /**
      * Sets the folder where to generate example using IVML models.
      * 
-     * @param folder the folder name (by default "src/test/easy")
+     * @param folder the folder name (by default "target/opcua-parser")
      */
     public static void setUsingIvmlFolder(String folder) {
         usingIvmlFolder = folder;
+    }
+
+    /**
+     * Returns the IVML output folder, creating it if needed.
+     *
+     * @return the IVML output folder
+     * @throws IllegalStateException if the folder cannot be created
+     */
+    private static File getUsingIvmlFolder() {
+        File result = new File(usingIvmlFolder);
+        if ((!result.isDirectory() && !result.mkdirs()) || !result.canWrite()) {
+            throw new IllegalStateException("Cannot create or write OPC UA parser output folder '" + result + "'");
+        }
+        return result;
     }
 
     /**
@@ -1415,8 +1430,9 @@ public class DomParser {
      * @param ivmlFile the output file
      */
     private void createIvmlModel(String fileName, File ivmlFile) {
+        File ivmlFolder = getUsingIvmlFolder();
         Generator.generateIVMLModel(fileName, ivmlFile, hierarchy);
-        Generator.generateVDWConnectorSettings(fileName, hierarchy, usingIvmlFolder);
+        Generator.generateVDWConnectorSettings(fileName, hierarchy, ivmlFolder.getPath());
         println("FINISHED");
     }
 
@@ -1570,10 +1586,15 @@ public class DomParser {
             //files.add(new File(baseDir, "Opc.Ua.Gds.NodeSet2.xml"));
             files.add(new File(baseDir, "Opc.Ua.Machinery.NodeSet2.xml"));
         }
+        File ivmlFolder = getUsingIvmlFolder();
+        File collectorFolder = new File("target/tmp");
+        if (!collectorFolder.isDirectory() && !collectorFolder.mkdirs()) {
+            throw new IllegalStateException("Cannot create OPC UA parser collector folder '" + collectorFolder + "'");
+        }
         for (File sourceFile : files) {
             String sourceFileName = sourceFile.getName();
             String modelName = getModelName(sourceFileName);
-            File ivmlFile = new File("target/gen/Opc" + modelName + ".ivml");
+            File ivmlFile = new File(ivmlFolder, "Opc" + modelName + ".ivml");
             process(sourceFile, modelName, ivmlFile, verboseDefault);
         }
         Collector.informationToExcel();

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -138,8 +138,8 @@ public class DomParserTest {
     public void testDomParserWhitespaceModelName() throws IOException, ModelManagementException {
         File nodeSets = new File("src/test/resources/NodeSets");
         File testFolder = new File("target/tmp/domParserWhitespaceModelName");
-        File output = new File("target/gen/OpcMachineTool.ivml");
-        File invalidOutput = new File("target/gen/OpcMachine Tool.ivml");
+        File output = new File(testFolder, "connector/OpcMachineTool.ivml");
+        File invalidOutput = new File(testFolder, "connector/OpcMachine Tool.ivml");
         if (testFolder.exists()) {
             FileUtils.deleteDirectory(testFolder);
         }
@@ -203,8 +203,8 @@ public class DomParserTest {
     public void testDomParserMultipleInputs() {
         File first = new File("src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml");
         File second = new File("src/test/resources/NodeSets/Opc.Ua.MachineTool.NodeSet2.xml");
-        File firstOut = new File("target/gen/OpcWoodworking.ivml");
-        File secondOut = new File("target/gen/OpcMachineTool.ivml");
+        File firstOut = new File("target/tmp/OpcWoodworking.ivml");
+        File secondOut = new File("target/tmp/OpcMachineTool.ivml");
         Assert.assertTrue(first.isFile());
         Assert.assertTrue(second.isFile());
         firstOut.getParentFile().mkdirs();

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/DomParserTest.java
@@ -39,13 +39,62 @@ import net.ssehub.easy.varModel.confModel.Configuration;
 public class DomParserTest {
 
     /**
+     * Tests creating and using a dedicated parser output folder.
+     *
+     * @throws IOException shall not occur
+     */
+    @Test
+    public void testDomParserOutputFolder() throws IOException {
+        File in = new File("src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml");
+        File output = new File("target/opcua-parser-test");
+        File legacyOutput = new File("src/test/easy/VDW_ToolOutput.ivml");
+        FileUtils.deleteDirectory(output);
+        Assert.assertFalse(output.exists());
+        Assert.assertFalse(legacyOutput.exists());
+        DomParser.setUsingIvmlFolder(output.getPath());
+        try {
+            DomParser.process(in, "ToolOutput", new File(output, "OpcToolOutput.ivml"), false);
+            Assert.assertTrue(new File(output, "OpcToolOutput.ivml").isFile());
+            Assert.assertTrue(new File(output, "VDW.ivml").isFile());
+            Assert.assertTrue(new File(output, "VDW_ToolOutput.ivml").isFile());
+            Assert.assertFalse(legacyOutput.exists());
+        } finally {
+            DomParser.setUsingIvmlFolder("target/tmp");
+            FileUtils.deleteDirectory(output);
+        }
+    }
+
+    /**
+     * Tests reporting an invalid parser output folder.
+     *
+     * @throws IOException shall not occur
+     */
+    @Test
+    public void testDomParserInvalidOutputFolder() throws IOException {
+        File output = new File("target/opcua-parser-output-file");
+        FileUtils.deleteQuietly(output);
+        Assert.assertTrue(output.createNewFile());
+        DomParser.setUsingIvmlFolder(output.getPath());
+        try {
+            DomParser.process(new File("src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml"),
+                "ToolOutput", new File(output, "OpcToolOutput.ivml"), false);
+            Assert.fail("Expected an invalid output folder to be rejected");
+        } catch (IllegalStateException e) {
+            Assert.assertTrue(e.getMessage().contains(output.getPath()));
+        } finally {
+            DomParser.setUsingIvmlFolder("target/tmp");
+            FileUtils.deleteQuietly(output);
+        }
+    }
+
+    /**
      * Tests processing one explicitly supplied companion specification.
      */
     @Test
     public void testDomParserSingleInput() {
         File in = new File("src/test/resources/NodeSets/Opc.Ua.MachineTool.NodeSet2.xml");
         Assert.assertTrue(in.isFile());
-        File out = new File("target/gen/OpcMachineTool.ivml");
+        File out = new File("target/tmp/OpcMachineTool.ivml");
         out.getParentFile().mkdirs();
         if (out.exists()) {
             Assert.assertTrue(out.delete());


### PR DESCRIPTION
(Hier wäre ich am vorsichtigsten. - Ich habe versucht sicherzustellen, dass es deinen Vorgaben entspricht, aber insgesamt ist die Frage was genau für Dich akzeptabel ist. - Eine einfachere Version basierte nur auf Compile-flags, wobei darüber dann geregelt wird, dass die commons für den Parser gefunden wird. Dies habe ich versucht zu vermeiden und zu homogenisieren.
Auch wurde versucht die Zahl der Änderungen zu minimieren. Die Gesamtzahl ist jedoch jetzt doch sehr hoch geworden. Wenngleich es sich zum Glück nicht über zu viele Dateien auswirkt.)

Die beiden Commits sind so aufgebaut: der erste umfasst einen noch etwas komplexen Aufruf. - Der zweite Commit vereinfacht das nochmal um möglichst wenige parameter für die expliziten Aufrufe zu haben. 

### Summary

Provide a reproducible opt-in execution path for the OPC UA NodeSet parser.

The parser is a development and generation tool used to transform OPC UA
NodeSet XML files into IVML. The generated IVML is used at runtime; the
parser and its Commons provider are not required by normal platform
applications.

### Problem

Executing DomParser through the normal Maven runtime classpath failed
because Commons.getInstance() could not resolve a provider.

support.commons-apache was available only as a test-scoped dependency,
so the parser worked only with test-compile and
exec.classpathScope=test.

The parser also assumed that output directories already existed and
defaulted generated IVML output to src/test/easy.

### Changes

- add the opt-in Maven profile OpcUaParser;
- provide support.commons-apache with runtime scope only while that
  profile is active;
- configure exec-maven-plugin for DomParser;
- support -Dopcua.ivml.output=<directory>;
- default parser output to target/opcua-parser;
- create required output directories automatically;
- reject invalid or non-writable output paths with a clear exception;
- preserve the existing test setter;
- document the parser invocation.

### Usage

From platform/configuration/configuration.easy:

```shell
mvn -PCfg,OpcUaParser compile exec:java \
    -Dexec.args=src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml
```

Generated files are written to `target/opcua-parser` by default.
Use `-Dopcua.ivml.output=<directory>` only to override that location.

### Validation

- public Woodworking parser smoke test: successful;
- DomParserTest: 5 tests, no failures or errors;
- complete configuration.easy module: 27 tests, no failures or errors;
- default dependency tree: no normal runtime dependency on
  support.commons-apache;
- OpcUaParser dependency tree:
  support.commons-apache is present with runtime scope;
- no files are generated under src/test/easy.
