### PR TITLE
Update generated OPC UA connector settings for IOTypeWithPath

### DIFF
--- a/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/Generator.java
+++ b/platform/configuration/configuration.easy/src/main/java/de/iip_ecosphere/platform/configuration/easyProducer/opcua/parser/Generator.java
@@ -90,7 +90,7 @@ public class Generator {
                 + "    deviceMgtStorageServer = S3MockDeviceMgtStorageServer{};\n\n"
                 + "    // ------------ data types ------------------\n\n" + "    RecordType opcIn = {\n"
                 + "        name = \"OpcIn\",\n" + "        fields = {\n" + "        }\n" + "    };    \n"
-                + "    RecordType opcOut = {\n" + "        path = \"PLACEHOLDER\",\n" + "        name = \"OpcOut\",\n\n"
+                + "    RecordType opcOut = {\n" + "        name = \"OpcOut\",\n\n"
                 + "        fields = {\n";
 
         String configEnding = "        \n}\n" + "    };\n\n"
@@ -100,7 +100,8 @@ public class Generator {
                 + "        ver = \"0.1.0\",\n" + "        host = \"opcua.umati.app\",\n"
                 + "        port = 4840, // default localhost\n" + "        \n"
                 + "        input = {{type=refBy(opcIn)}},\n" + "        output = {{type=refBy(opcOut)}},\n"
-                + "        inInterface = refBy(opcIn), \n" + "        outInterface = refBy(opcOut)\n"
+                + "        inInterface = {{type=refBy(opcIn)}}, \n"
+                + "        outInterface = {{type=refBy(opcOut), path=\"PLACEHOLDER\"}}\n"
                 + "        /*operations = {\n" + "          FieldAssignmentOperation{field=myConnPltfIn.fields[1], \n"
                 + "            operation=AddDataTranslationOperation{\n" + "                arguments={\n"
                 + "                    DataFieldAccess{field=myConnMachineOut.fields[0]},\n"

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/AllTests.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/AllTests.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import test.de.iip_ecosphere.platform.configuration.easyProducer.opcua.DomParserTest;
+import test.de.iip_ecosphere.platform.configuration.easyProducer.opcua.GeneratorTest;
 
 /**
  * Defines the tests to be executed.
@@ -39,7 +40,8 @@ import test.de.iip_ecosphere.platform.configuration.easyProducer.opcua.DomParser
     AasIvmlMapperTest.class,
     CommentTests.class,
 
-    DomParserTest.class
+    DomParserTest.class,
+    GeneratorTest.class
 })
 public class AllTests {
 }

--- a/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/GeneratorTest.java
+++ b/platform/configuration/configuration.easy/src/test/java/test/de/iip_ecosphere/platform/configuration/easyProducer/opcua/GeneratorTest.java
@@ -1,0 +1,81 @@
+/**
+ * ******************************************************************************
+ * Copyright (c) {2026} The original author or authors
+ *
+ * All rights reserved. This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0 which is available
+ * at http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR EPL-2.0
+ ********************************************************************************/
+
+package test.de.iip_ecosphere.platform.configuration.easyProducer.opcua;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.iip_ecosphere.platform.configuration.easyProducer.ConfigurationLifecycleDescriptor;
+import de.iip_ecosphere.platform.configuration.easyProducer.ConfigurationLifecycleDescriptor.ExecutionMode;
+import de.iip_ecosphere.platform.configuration.easyProducer.ConfigurationManager;
+import de.iip_ecosphere.platform.configuration.easyProducer.ConfigurationSetup;
+import de.iip_ecosphere.platform.configuration.easyProducer.ivml.IvmlUtils;
+import de.iip_ecosphere.platform.configuration.easyProducer.opcua.parser.DomParser;
+import de.iip_ecosphere.platform.support.FileUtils;
+import net.ssehub.easy.reasoning.core.reasoner.ReasoningResult;
+import test.de.iip_ecosphere.platform.configuration.easyProducer.AbstractIvmlTests;
+
+/**
+ * Tests the OPC UA connector settings generator.
+ *
+ * @author Codex, SSE
+ */
+public class GeneratorTest extends AbstractIvmlTests {
+
+    /**
+     * Tests that generated connector settings comply with the current IVML meta model.
+     *
+     * @throws IOException if handling the generated files fails
+     */
+    @Test
+    public void testGeneratedConnectorSettings() throws IOException {
+        File output = new File("target/generated-opcua-connector-test");
+        FileUtils.deleteDirectory(output);
+        Assert.assertTrue(output.mkdirs());
+        DomParser.setUsingIvmlFolder(output.getPath());
+        ConfigurationLifecycleDescriptor lifecycle = null;
+        try {
+            File input = new File("src/test/resources/NodeSets/Opc.Ua.Woodworking.NodeSet2.xml");
+            DomParser.process(input, "Woodworking", new File(output, "OpcWoodworking.ivml"), false);
+
+            TestConfigurer configurer = new TestConfigurer("VDW", output, TEST_BASE_FOLDER);
+            ConfigurationSetup setup = ConfigurationSetup.getSetup(false);
+            configurer.configure(setup);
+            lifecycle = configurer.obtainLifecycleDescriptor();
+            lifecycle.startup(ExecutionMode.IVML_QUIET, new String[0]);
+            ConfigurationManager.reInit();
+            ReasoningResult result = ConfigurationManager.validateAndPropagate();
+            Assert.assertNotNull("Generated VDW model was not loaded", result);
+            Assert.assertFalse(IvmlUtils.analyzeReasoningResult(result, false, true));
+
+            String generated = FileUtils.readFileToString(new File(output, "VDW.ivml"),
+                StandardCharsets.UTF_8);
+            Assert.assertFalse(generated.contains("RecordType opcOut = {\n        path ="));
+            Assert.assertTrue(generated.contains("inInterface = {{type=refBy(opcIn)}}"));
+            Assert.assertTrue(generated.contains(
+                "outInterface = {{type=refBy(opcOut), path=\"PLACEHOLDER\"}}"));
+        } finally {
+            if (lifecycle != null) {
+                lifecycle.shutdown();
+            }
+            ConfigurationSetup.getSetup(false).getEasyProducer().reset();
+            DomParser.setUsingIvmlFolder("target/tmp");
+            FileUtils.deleteQuietly(output);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

Update the OPC UA connector settings generator to produce interface
mappings compatible with the current IVML connector meta model.

## Problem

The generated connector model used an outdated structure:

- `path` was assigned directly to `RecordType opcOut`, although
  `RecordType` no longer defines that field;
- `inInterface` and `outInterface` were assigned direct record
  references;
- the current meta model expects `sequenceOf(IOTypeWithPath)`.

As a result, the generated `VDW.ivml` could be written, but it could not
be loaded and validated against the current connector meta model.

## Changes

- remove the obsolete `path` assignment from `RecordType opcOut`;
- generate `inInterface` as an `IOTypeWithPath` sequence entry;
- generate `outInterface` as an `IOTypeWithPath` sequence entry carrying
  the existing path value;
- add a regression test that transforms the public Woodworking NodeSet,
  loads the generated `VDW.ivml`, runs reasoning and verifies both
  generated interface mappings;
- register the regression test in the normal module suite.

## Generated structure

    inInterface = {{type=refBy(opcIn)}},
    outInterface = {{type=refBy(opcOut), path="PLACEHOLDER"}}

The existing `input` and `output` declarations remain unchanged.

## Validation

- `GeneratorTest`: 1 test, no failures or errors;
- complete `configuration.easy` module: 26 tests, no failures or errors;
- the generated public Woodworking connector model loads and reasons
  successfully;
- a local Machinery Energy integration validation also loaded and
  reasoned the generated OPC and connector models successfully.

The private Machinery Energy input is not part of this pull request.

## Scope

This pull request only updates the generated connector interface
structure and adds regression coverage. It does not change OPC UA
parsing, external type resolution, parser tooling, Maven profiles,
connector runtime behavior or dependency configuration.
